### PR TITLE
bug fixed- randomly failing- certificate test case

### DIFF
--- a/test/unit/certificate.test.js
+++ b/test/unit/certificate.test.js
@@ -5,10 +5,20 @@ const certificateController = require('../../src/controllers/certificate.control
 const Certificate = require('../../src/models/certificate.model');
 
 test('should return certificate details when valid certificate id is provided', async () => {
-    const existingCertificate = await Certificate.findOne({});
+    const certificate = new Certificate({
+        userGithubId: "test-open-certs-userId",
+        userName: "test-open-certs-userId",
+        projectRepo: "open-certs",
+        projectOwner: "open-certs",
+        commitCount: 0,
+        pullRequestCount: 0,
+        lastContributionDate: new Date(),
+        images: []
+    })
+    await certificate.save();    
     const mReq = {
         params: {
-            id: String(existingCertificate._id)
+            id: String(certificate._id)
         }
     };
     const mRes = {
@@ -17,7 +27,7 @@ test('should return certificate details when valid certificate id is provided', 
             expect(x).toBeTruthy();
             expect(x.error).toBeUndefined();
             expect(String(x.certificate._id)).toBe(
-                String(existingCertificate._id)
+                String(certificate._id)
             );
         })
     };


### PR DESCRIPTION
# Description:

Test should return certificate details when valid certificate id is provided randomly fails when there is no certificates already generated in the DB. Created a sample test case to test it.

Fixes # (issue no.)

44

## Type of change:

-   [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

-   [x] My code follows the style guidelines of this project.
-   [x] I have performed a self-review of my own code.
-   [x] My changes generate no new warnings.
-   [x] I have added tests that prove my fix is effective or that my feature works.
-   [x] New and existing unit tests pass locally with my changes.
-   [x] Any dependent changes have been merged and published in downstream modules.

# Screenshots / Video:
Earlier:
![image](https://user-images.githubusercontent.com/100365349/159276714-ad817bbf-e5b9-4a65-b844-4ff5a85aca5f.png)

Now:
![image](https://user-images.githubusercontent.com/100365349/159276372-564b157c-1f4d-476b-9075-a16947c8594d.png)



